### PR TITLE
Ajusta a compatibilidade com a UI do Plasmoid do KDE Plasma 6.6 (versão atual)

### DIFF
--- a/plasma-widget/contents/ui/main.qml
+++ b/plasma-widget/contents/ui/main.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Controls as Controls
 import org.kde.plasma.plasmoid
-import org.kde.plasma.components as PlasmaComponents3
 import org.kde.plasma.plasma5support as Plasma5Support
 import org.kde.kirigami as Kirigami
 import "../code/translations.js" as Translations
@@ -214,19 +214,19 @@ PlasmoidItem {
             anchors.margins: Kirigami.Units.smallSpacing
 
             // Status compacto
-            PlasmaComponents3.Label {
+            Controls.Label {
                 id: statusLabel
                 text: isConnected ? "✓ " + deviceName : "❌ " + Translations._('not_found')
                 font.pointSize: Kirigami.Theme.smallFont.pointSize
                 Layout.fillWidth: true
             }
 
-            PlasmaComponents3.Separator {
+            Kirigami.Separator {
                 Layout.fillWidth: true
             }
 
             // Volume grande
-            PlasmaComponents3.Label {
+            Controls.Label {
                 id: volumeLabel
                 text: currentVolume + " %"
                 font.pointSize: Kirigami.Theme.defaultFont.pointSize * 1.5
@@ -237,7 +237,7 @@ PlasmoidItem {
                 Layout.bottomMargin: Kirigami.Units.smallSpacing
             }
 
-            PlasmaComponents3.Separator {
+            Kirigami.Separator {
                 Layout.fillWidth: true
             }
 
@@ -252,7 +252,7 @@ PlasmoidItem {
                     implicitHeight: Kirigami.Units.iconSizes.small
                 }
 
-                PlasmaComponents3.Slider {
+                Controls.Slider {
                     id: volumeSlider
                     Layout.fillWidth: true
                     from: 0
@@ -280,12 +280,12 @@ PlasmoidItem {
                 }
             }
 
-            PlasmaComponents3.Separator {
+            Kirigami.Separator {
                 Layout.fillWidth: true
             }
 
             // Botão de mute
-            PlasmaComponents3.Button {
+            Controls.Button {
                 id: muteButton
                 Layout.fillWidth: true
                 text: isMuted ? "🔊 " + Translations._('unmute') : "🔇 " + Translations._('mute')
@@ -293,7 +293,7 @@ PlasmoidItem {
             }
 
             // Botão para definir como saída padrão
-            PlasmaComponents3.Button {
+            Controls.Button {
                 Layout.fillWidth: true
                 text: "🔊 " + Translations._('use_as_output')
                 onClicked: setAsDefaultSink()


### PR DESCRIPTION
# Basicamente, um ajuste na UI do Plasmoid

Infelizmente não tive sorte de conseguir controlar através destes controles, não consigo de jeito algum corrigir o erro do CLI retornando "Error communicating with daemon", porém o redragon-hs-companion funciona normalmente no "automático" (controlando via widget de volume do próprio KDE Plasma, sincronizando os fones em background) e agradeço imensamente por ter feito esse projeto. 

Mas, além disso, notei que a UI do Plasmoid está quebrada, verifiquei os erros e era atualizações de alguns recursos que mudaram do PlasmaComponents3 para o Kirigami, outros migraram para os widgets do próprio QT, talvez ajude alguém que teve mais sorte que eu.


<img width="692" height="579" alt="Captura_de_tela_20260323_184722" src="https://github.com/user-attachments/assets/dc602d6b-3f1a-46a9-86ae-e9db94ae9844" />

## Ajustes

Fiz estes pequenos ajustes consultando a documentação https://develop.kde.org/docs/getting-started/kirigami/components-controls/ e aparenta estar funcional, sem apresentar os erros dos componentes antigos.

https://github.com/user-attachments/assets/afbdfa0d-708a-4158-ab5c-9d048f370a74


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only component migration; behavior should be unchanged aside from styling/layout differences due to new control types.
> 
> **Overview**
> Migrates the plasmoid’s `fullRepresentation` UI away from deprecated `PlasmaComponents3` widgets to Plasma 6.6-compatible components.
> 
> `Label`, `Slider`, and `Button` are switched to `QtQuick.Controls` (via `Controls.*`), and separators are replaced with `Kirigami.Separator`, with the corresponding import updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1c82556bd0435058450937465c55e9329e53abd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->